### PR TITLE
Add `cascade: true` to interpolation by default.

### DIFF
--- a/lib/text_helpers/translation.rb
+++ b/lib/text_helpers/translation.rb
@@ -26,9 +26,12 @@ module TextHelpers
         default: "!#{key}!"
       }.merge(options)).strip
 
+      interpolation_options = options.dup
+      interpolation_options[:cascade] = true unless interpolation_options.has_key?(:cascade)
+
       # Interpolate any keypaths (e.g., `!some.lookup.path/key!`) found in the text.
       while text =~ /!([\w._\/]+)!/ do
-        text = text.gsub(/!([\w._\/]+)!/) { |match| I18n.t($1, options) }
+        text = text.gsub(/!([\w._\/]+)!/) { |match| I18n.t($1, interpolation_options) }
       end
 
       text = smartify(text) if options.fetch(:smart, true)

--- a/test/lib/text_helpers/translation_test.rb
+++ b/test/lib/text_helpers/translation_test.rb
@@ -183,11 +183,7 @@ describe TextHelpers::Translation do
         before do
           @original_backend = I18n.backend
           new_backend = @original_backend.dup
-
-          class << new_backend
-            include I18n::Backend::Cascade
-          end
-
+          new_backend.extend(I18n::Backend::Cascade)
           I18n.backend = new_backend
         end
 

--- a/test/lib/text_helpers/translation_test.rb
+++ b/test/lib/text_helpers/translation_test.rb
@@ -4,6 +4,7 @@ describe TextHelpers::Translation do
   before do
     @helper = Object.send(:include, TextHelpers::Translation).new
   end
+
   describe "given a stored I18n lookup" do
     before do
       @scoped_text = "Scoped lookup"
@@ -17,26 +18,33 @@ describe TextHelpers::Translation do
 
       @nb_scoped_text = "Scoped&nbsp;lookup"
 
+      I18n.exception_handler = nil
+
       I18n.backend.store_translations :en, {
         test_key: @global_text,
         multiline_key: @multiline_text,
         interpolated_key: "%{interpolate_with}",
         test: {
-          email_key:        "<#{@email_address}>",
-          test_key:         "*#{@scoped_text}*",
-          list_key:         "* #{@scoped_text}",
-          interpolated_key: "Global? (!test_key!)",
-          interpol_arg_key: "Interpolate global? (!interpolated_key!)",
-          recursive_key:    "Recursively !test.interpolated_key!",
-          quoted_key:       "They're looking for \"#{@global_text}\"--#{@scoped_text}",
-          argument_key:     "This is what %{user} said",
-          number_key:       "120\"",
+          email_key:               "<#{@email_address}>",
+          test_key:                "*#{@scoped_text}*",
+          list_key:                "* #{@scoped_text}",
+          interpolated_key:        "Global? (!test_key!)",
+          interpolated_scoped_key: "Global? (!test_scoped_key!)",
+          interpol_arg_key:        "Interpolate global? (!interpolated_key!)",
+          recursive_key:           "Recursively !test.interpolated_key!",
+          quoted_key:              "They're looking for \"#{@global_text}\"--#{@scoped_text}",
+          argument_key:            "This is what %{user} said",
+          number_key:              "120\"",
           pluralized_key: {
             one:            "A single piece of text",
             other:          "%{count} pieces of text"
           }
         }
       }
+    end
+
+    after do
+      I18n.backend.reload!
     end
 
     describe "for a specified scope" do
@@ -149,6 +157,56 @@ describe TextHelpers::Translation do
 
       it "defaults to a globally-defined value for the key" do
         assert_equal @global_text, @helper.text(:test_key)
+      end
+    end
+
+    describe "when a scope is given as an option" do
+      before do
+        @helper.define_singleton_method :translation_scope do
+          'test'
+        end
+      end
+
+      it "shows translation missing if an interpolated key isn't found at the same scope" do
+        expected = "Global? (translation missing: en.test.test_scoped_key)"
+        assert_equal expected, @helper.text(:interpolated_scoped_key, scope: "test")
+      end
+
+      it "interpolates the key if one is found at the same scope" do
+        I18n.backend.store_translations(:en, {
+          test: {test_scoped_key: "a translation"}})
+
+        assert_equal "Global? (a translation)", @helper.text(:interpolated_scoped_key, scope: "test")
+      end
+
+      describe "with the Cascade backend in place" do
+        before do
+          @original_backend = I18n.backend
+          new_backend = @original_backend.dup
+
+          class << new_backend
+            include I18n::Backend::Cascade
+          end
+
+          I18n.backend = new_backend
+        end
+
+        after do
+          I18n.backend = @original_backend
+        end
+
+        it "cascades the interpolated key by default" do
+          I18n.backend.store_translations(:en, {test_scoped_key: "a translation"})
+
+          assert_equal "Global? (a translation)", @helper.text(:interpolated_scoped_key, scope: "test")
+        end
+
+        it "doesn't cascade if cascade: false is passed" do
+          I18n.backend.store_translations(:en, {test_scoped_key: "a translation"})
+
+          expected = "Global? (translation missing: en.test.test_scoped_key)"
+          assert_equal expected, @helper.text(:interpolated_scoped_key, scope: "test", cascade: false)
+        end
       end
     end
   end


### PR DESCRIPTION
This PR can maybe be deleted in favour of some other fix, but basically:

https://github.com/ahorner/text-helpers/commit/dc349ccbb53f29e75c14069027a41860f1295ad5?diff=unified#diff-e092322eb3a058c18e9fe3668d80b994R31

broke usage in a lot of cases (specifying a `scope` while also trying to interpolate keys defined at a higher level in the tree). This fixes it by setting `cascade: true` when interpolating, which when used with the `Cascade` backend, provides similar (though not exactly the same) behaviour as before.