### PR TITLE
Update for compatibility with RSpec 3.

### DIFF
--- a/lib/text_helpers/contexts.rb
+++ b/lib/text_helpers/contexts.rb
@@ -21,9 +21,8 @@ shared_context "a view spec", view: true do
 
   def translation_scope
     matcher = /(?<path>.*)\/_?(?<view>[^\/.]+)(?<extension>\.html\.haml)?/
-    info = matcher.match(example.metadata[:full_description])
+    info = matcher.match(_default_file_to_render)
     path = info[:path].gsub('/', '.')
-
     "views.#{path}.#{info[:view]}"
   end
 end


### PR DESCRIPTION
`example` isn't available in the scope this is used in now, but _default_file_to_render is. Tested on an app using it extensively under both RSpec 2 and 3.