### PR TITLE
Always add locales in sorted order

### DIFF
--- a/lib/text_helpers/railtie.rb
+++ b/lib/text_helpers/railtie.rb
@@ -59,7 +59,7 @@ module TextHelpers
 
     initializer "text_helpers.i18n.add_load_paths" do |app|
       locales = Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s
-      app.config.i18n.load_path += Dir[locales]
+      app.config.i18n.load_path += Dir[locales].sort
     end
 
     initializer "text_helpers.setup_exception_handling", after: 'after_initialize' do


### PR DESCRIPTION
In my en.yml, I overwrite some settings from devise.en.yml...but recently I have seen different behavior:

On my laptop, I am seeing the `Dir` return files in a different order:

before the fix:
```
pry(main)> Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
=> ["/project/config/locales/en.yml",
 "/project/config/locales/devise.en.yml",
 "/project/config/locales/controllers/application.en.yml",
 "/project/config/locales/views/kaminari.en.yml",
 "/project/config/locales/views/layouts/head.en.yml",
 "/project/config/locales/simple_form.en.yml",
 "/project/config/locales/faker.en.yml"]
 ```

after the fix (note that devise.en.yml is now before en.yml):
```
[7] pry(main)> Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s].sort
=> ["/project/config/locales/controllers/application.en.yml",
 "/project/config/locales/devise.en.yml",
 "/project/config/locales/en.yml",
 "/project/config/locales/faker.en.yml",
 "/project/config/locales/simple_form.en.yml",
 "/project/config/locales/views/kaminari.en.yml",
 "/project/config/locales/views/layouts/head.en.yml"]
```