### PR TITLE
Fix an issue in exception handler for the Pluralization backend

### DIFF
--- a/lib/text_helpers.rb
+++ b/lib/text_helpers.rb
@@ -5,10 +5,10 @@ require "text_helpers/railtie" if defined?(Rails)
 module TextHelpers
   # RaiseExceptionHandler just raises all exceptions, rather than swallowing
   # MissingTranslation ones. It's cribbed almost verbatim from
-  # http://edgeguides.rubyonrails.org/i18n.html#customize-your-i18n-setup.
+  # https://guides.rubyonrails.org/i18n.html#using-different-exception-handlers.
   class RaiseExceptionHandler < I18n::ExceptionHandler
     def call(exception, locale, key, options)
-      if exception.is_a?(I18n::MissingTranslation)
+      if exception.is_a?(I18n::MissingTranslation) && key.to_s != "i18n.plural.rule"
         raise exception.to_exception
       else
         super

--- a/test/lib/text_helpers/translation_test.rb
+++ b/test/lib/text_helpers/translation_test.rb
@@ -171,9 +171,31 @@ describe TextHelpers::Translation do
         assert_equal "This is what <b>Han</b> Solo said", @helper.text(:argument_key, user: "<b>Han</b> Solo".html_safe)
       end
 
-      it "correctly handles non-string params" do
+      it "correctly handles pluralized keys" do
         assert_equal "A single piece of text", @helper.text(:pluralized_key, count: 1)
         assert_equal "2 pieces of text", @helper.text(:pluralized_key, count: 2)
+      end
+
+      describe "when the pluralization backend is configured and the exception handler is enabled" do
+        before do
+          @original_backend = I18n.backend
+          new_backend = @original_backend.dup
+          new_backend.extend(I18n::Backend::Pluralization)
+          I18n.backend = new_backend
+
+          @original_exception_handler = I18n.exception_handler
+          I18n.exception_handler = TextHelpers::RaiseExceptionHandler.new
+        end
+
+        after do
+          I18n.backend = @original_backend
+          I18n.exception_handler = @original_exception_handler
+        end
+
+        it "correctly handles pluralized keys" do
+          assert_equal "A single piece of text", @helper.text(:pluralized_key, count: 1)
+          assert_equal "2 pieces of text", @helper.text(:pluralized_key, count: 2)
+        end
       end
     end
 


### PR DESCRIPTION
If the I18n::Backend::Pluralization backend is enabled, trying to access a pluralized
key (e.g. `one: "1 thing", other: "%{count} things"`) would end up raising a missing
translation error on `i18n.plural.rule`. The exception handler was catching this and raising it on up. What should be happening is that it falls back to the default pluralization rules.

This fix is described in the same place the original exception handler code came
from: https://guides.rubyonrails.org/i18n.html#using-different-exception-handlers

I updated the anchor to be a little more precise and to link to the stable guide
rather than edge.