### PR TITLE
Removes deprecation warning for Rails 6.1

### DIFF
--- a/lib/text_helpers/railtie.rb
+++ b/lib/text_helpers/railtie.rb
@@ -65,7 +65,7 @@ module TextHelpers
     initializer "text_helpers.setup_exception_handling", after: 'after_initialize' do
       next unless config.text_helpers.raise_on_missing_translations
 
-      if Rails::VERSION::MAJOR >= 7
+      if Rails::VERSION::MAJOR >= 7 || (Rails::VERSION::MAJOR == 6 && Rails::VERSION::MINOR >= 1)
         if config.respond_to?(:i18n)
           config.i18n.raise_on_missing_translations = true
         end


### PR DESCRIPTION
I'm currently working on removing all deprecation warnings from a Rails 6.1 codebase in preparation for upgrading to Rails 7. I eventually traced the line:

```
DEPRECATION WARNING: action_view.raise_on_missing_translations is deprecated and will be removed in Rails 7.0. Set i18n.raise_on_missing_translations instead. Note that this new setting also affects how missing translations are handled in controllers.
```

to this file. This changes it so folks using Rails 6.1 will no longer see the deprecation warning.